### PR TITLE
support quart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Unreleased
 
+-   Support Quart.
+
 ## Version 0.1.0
 
 Released 2025-02-11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,11 @@ dependencies = [
     "flask>=3",
 ]
 
+[project.optional-dependencies]
+quart = [
+    "quart>=0.20",
+]
+
 [project.urls]
 Documentation = "https://flask-email-simplified.readthedocs.io"
 Changes = "https://flask-email-simplified.readthedocs.io/en/latest/changes/"
@@ -28,6 +33,7 @@ dev = [
     "pyright",
     "pytest",
     "pytest-cov",
+    "quart",
     "ruff",
     "tox",
     "tox-uv",
@@ -50,11 +56,13 @@ pre-commit = [
 tests = [
     "pytest",
     "pytest-cov",
+    "quart",
 ]
 typing = [
     "mypy",
     "pyright",
     "pytest",
+    "quart",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_quart.py
+++ b/tests/test_quart.py
@@ -1,0 +1,75 @@
+import asyncio
+
+import pytest
+from email_simplified import Message
+from email_simplified import SMTPEmailHandler
+from flask import Flask
+from quart import Quart
+
+from flask_email_simplified import EmailExtension
+
+
+def test_init() -> None:
+    app = Quart(__name__)
+    app.testing = True
+    app.config["EMAIL_USERNAME"] = "test"
+    app.config["EMAIL_TESTING_KEEP_HANDLER"] = True
+    email = EmailExtension(app)
+
+    async def inner() -> None:
+        with pytest.raises(RuntimeError):
+            assert email.handler
+
+        async with app.app_context():
+            handler = email.handler
+
+        assert isinstance(handler, SMTPEmailHandler)
+        assert handler.username == "test"
+
+    asyncio.run(inner())
+
+
+def test_send() -> None:
+    app = Quart(__name__)
+    app.testing = True
+    email = EmailExtension(app)
+
+    async def inner() -> None:
+        async with app.app_context():
+            await email.send_async(Message(subject="a"))
+            assert email.handler.outbox  # type: ignore[attr-defined]
+
+    asyncio.run(inner())
+
+
+def test_no_init() -> None:
+    email = EmailExtension()
+
+    with pytest.raises(RuntimeError):
+        assert email.handler
+
+
+def test_both_init() -> None:
+    email = EmailExtension()
+    flask_app = Flask(__name__)
+    quart_app = Quart(__name__)
+    email.init_app(flask_app)
+    email.init_app(quart_app)
+
+    with pytest.raises(RuntimeError):
+        assert email.handler
+
+    with flask_app.app_context():
+        flask_handler: object = email.handler
+
+    quart_handler: object = None
+
+    async def inner() -> None:
+        nonlocal quart_handler
+
+        async with quart_app.app_context():
+            quart_handler = email.handler
+
+    asyncio.run(inner())
+    assert quart_handler is not None
+    assert flask_handler is not quart_handler

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "24.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896 },
+]
+
+[[package]]
 name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -288,6 +297,11 @@ dependencies = [
     { name = "flask" },
 ]
 
+[package.optional-dependencies]
+quart = [
+    { name = "quart" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -295,6 +309,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "quart" },
     { name = "ruff" },
     { name = "tox" },
     { name = "tox-uv" },
@@ -317,17 +332,20 @@ pre-commit = [
 tests = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "quart" },
 ]
 typing = [
     { name = "mypy" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "quart" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "email-simplified", specifier = ">=0.1" },
     { name = "flask", specifier = ">=3" },
+    { name = "quart", marker = "extra == 'quart'", specifier = ">=0.20" },
 ]
 
 [package.metadata.requires-dev]
@@ -337,6 +355,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "quart" },
     { name = "ruff" },
     { name = "tox" },
     { name = "tox-uv" },
@@ -353,11 +372,13 @@ pre-commit = [{ name = "pre-commit" }]
 tests = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "quart" },
 ]
 typing = [
     { name = "mypy" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "quart" },
 ]
 
 [[package]]
@@ -398,6 +419,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/38/d7f80fd13e6582fb8e0df8c9a653dcc02b03ca34f4d72f34869298c5baf8/h2-4.2.0.tar.gz", hash = "sha256:c8a52129695e88b1a0578d8d2cc6842bbd79128ac685463b887ee278126ad01f", size = 2150682 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/9e/984486f2d0a0bd2b024bf4bc1c62688fcafa9e61991f041fb0e2def4a982/h2-4.2.0-py3-none-any.whl", hash = "sha256:479a53ad425bb29af087f3458a61d30780bc818e4ebcf01f0b536ba916462ed0", size = 60957 },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357 },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -423,6 +466,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "hypercorn"
+version = "0.17.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "h2" },
+    { name = "priority" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/3a/df6c27642e0dcb7aff688ca4be982f0fb5d89f2afd3096dc75347c16140f/hypercorn-0.17.3.tar.gz", hash = "sha256:1b37802ee3ac52d2d85270700d565787ab16cf19e1462ccfa9f089ca17574165", size = 44409 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/3b/dfa13a8d96aa24e40ea74a975a9906cfdc2ab2f4e3b498862a57052f04eb/hypercorn-0.17.3-py3-none-any.whl", hash = "sha256:059215dec34537f9d40a69258d323f56344805efb462959e727152b0aa504547", size = 61742 },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007 },
 ]
 
 [[package]]
@@ -673,6 +740,15 @@ wheels = [
 ]
 
 [[package]]
+name = "priority"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/3c/eb7c35f4dcede96fca1842dac5f4f5d15511aa4b52f3a961219e68ae9204/priority-2.0.0.tar.gz", hash = "sha256:c965d54f1b8d0d0b19479db3924c7c36cf672dbf2aec92d43fbdaf4492ba18c0", size = 24792 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl", hash = "sha256:6f8eefce5f3ad59baf2c080a664037bb4725cd0a790d53d59ab4059288faf6aa", size = 8946 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -767,6 +843,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+]
+
+[[package]]
+name = "quart"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "blinker" },
+    { name = "click" },
+    { name = "flask" },
+    { name = "hypercorn" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/9d/12e1143a5bd2ccc05c293a6f5ae1df8fd94a8fc1440ecc6c344b2b30ce13/quart-0.20.0.tar.gz", hash = "sha256:08793c206ff832483586f5ae47018c7e40bdd75d886fee3fabbdaa70c2cf505d", size = 63874 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/e9/cc28f21f52913adf333f653b9e0a3bf9cb223f5083a26422968ba73edd8d/quart-0.20.0-py3-none-any.whl", hash = "sha256:003c08f551746710acb757de49d9b768986fd431517d0eb127380b656b98b8f1", size = 77960 },
 ]
 
 [[package]]
@@ -1215,4 +1311,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498 },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/4a/44d3c295350d776427904d73c189e10aeae66d7f555bb2feee16d1e4ba5a/wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065", size = 53425 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/58/e860788190eba3bcce367f74d29c4675466ce8dddfba85f7827588416f01/wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736", size = 24226 },
 ]


### PR DESCRIPTION
Forgot to actually check that this worked when I said so in 0.1. Just using `App` instead of `Flask` isn't enough, still have to know which global context to look at.

`init_app` checks if the app is a `Flask` instance. If it is, it records `self.flask_ctx = flask.globals.app_ctx`. Otherwise, it records `self.quart_ctx = quart.globals.app_ctx`. When accessing `handler`, which requires an `App` for lookup, it can check whichever ctx is not none (or check both). Technically, this allows initing the same extension on Flask and Quart apps at the same time, in which case it has to do a little extra work sometimes, since it checks Quart's ctx second. But typically only one type of app will be registered, and so the other ctx will be none and skipped.

I don't know of any extension that has tried this yet, but it seems to work.